### PR TITLE
Switch to flutter_timezone

### DIFF
--- a/lib/timezone_dropdown.dart
+++ b/lib/timezone_dropdown.dart
@@ -2,7 +2,7 @@ library timezone_dropdown;
 
 import 'package:dropdown_search/dropdown_search.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_native_timezone/flutter_native_timezone.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:timezone/timezone.dart' as tz;
 import 'package:timezone/data/latest.dart' as tz;
 
@@ -37,7 +37,7 @@ class TimezoneDropdownState extends State<TimezoneDropdown> {
   }
 
   void loadTimeZones() async {
-    myTz = await FlutterNativeTimezone.getLocalTimezone();
+    myTz = await FlutterTimezone.getLocalTimezone();
 
     widget.onTimezoneSelected(myTz!);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   dropdown_search: ^5.0.6
   flutter:
     sdk: flutter
-  flutter_native_timezone: ^2.0.0
+  flutter_timezone: ^1.0.8
   timezone: ^0.9.2
 
 dev_dependencies:


### PR DESCRIPTION
I ran into compatibilty issues with the flutter_native_timezone package.
The original [flutter_native_timezone](https://github.com/pinkfish/flutter_native_timezone) is no longer maintained. But the fork [flutter_timezone](https://github.com/tjarvstrand/flutter_timezone) still gets updates.
